### PR TITLE
trap時にnull変数に対してRequestSerializationを呼び出すように変更

### DIFF
--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use crate::ir::{module::Module, ty::CsType, DATA, ELEMENT, STACK, STACK_SIZE, STACK_TOP};
+use crate::ir::{module::Module, ty::CsType, DATA, ELEMENT, NULL, STACK, STACK_SIZE, STACK_TOP};
 
 use super::func::codegen_func;
 
@@ -112,6 +112,11 @@ pub fn codegen_module(module: &Module<'_>, f: &mut dyn io::Write) -> io::Result<
     // 再帰呼び出しで保存するローカル変数用のスタック
     writeln!(f, "object[] {STACK} = new object[{STACK_SIZE}];")?;
     writeln!(f, "int {STACK_TOP} = 0;")?;
+
+    // trap用のnull変数
+    if !module.test {
+        writeln!(f, "UdonSharpBehaviour {NULL} = null;")?;
+    }
 
     writeln!(f, "}}")?;
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -25,6 +25,7 @@ pub const VAR: &str = "w2us_v";
 pub const LOOP: &str = "w2us_loop";
 pub const STACK: &str = "w2us_stack";
 pub const STACK_TOP: &str = "w2us_stack_top";
+pub const NULL: &str = "w2us_null";
 pub const START: &str = "w2us_start";
 
 pub fn func_header(
@@ -50,8 +51,6 @@ pub fn trap(module: &Module<'_>, message: &str) -> String {
         format!(r#"throw new Exception("{message}");"#)
     } else {
         // エラー時にはnullのメソッドを呼び出すことで例外を出して停止する
-        format!(
-            r#"Debug.LogError("{message}"); ((UdonSharpBehaviour)null).GetProgramVariable("");"#
-        )
+        format!(r#"Debug.LogError("{message}"); {NULL}.RequestSerialization();"#)
     }
 }


### PR DESCRIPTION
UdonSharpでコンパイルされた後のUdonAssemblyコードを短くするため
UdonSharpBehaviour型のnull変数を使うことで、nullをキャストするコードを生成しない 引数と戻り値が存在しないRequestSerializationを使うことでUdonのPUSH命令を削減