### PR TITLE
未割り当てのローカル変数が使用されるバグを修正

### DIFF
--- a/src/pass.rs
+++ b/src/pass.rs
@@ -16,12 +16,13 @@ pub fn run_passes(module: &mut Module<'_>) {
     recursive(module);
 
     for func in module.all_funcs.iter_mut() {
+        let func_ty = &func.header.ty;
         let Some(code) = func.code.as_mut() else {
             continue;
         };
 
         breakable(code);
-        copy_propagation(code);
+        copy_propagation(func_ty, code);
         remove_unused_vars(code);
         remove_unused_break_depth(code);
     }

--- a/src/pass/copy_propagation.rs
+++ b/src/pass/copy_propagation.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
-use cranelift_entity::SecondaryMap;
+use cranelift_entity::{EntityRef, SecondaryMap};
+use wasmparser::FuncType;
 
 use crate::{
     ir::{
@@ -18,14 +19,14 @@ enum Def {
     Inst(InstId),
 }
 
-pub fn copy_propagation(code: &mut Code) {
+pub fn copy_propagation(func_ty: &FuncType, code: &mut Code) {
     let (use_defs, def_uses) = reaching_def(
         code,
         #[cfg(test)]
         None,
     );
     let copy_in = copy(code);
-    replace_copy(code, &use_defs, &def_uses, &copy_in);
+    replace_copy(func_ty, code, &use_defs, &def_uses, &copy_in);
 }
 
 /// テスト時には引数のin_setsにReaching definitionのinを出力する
@@ -363,6 +364,7 @@ fn is_copy(inst: &Inst) -> bool {
 
 /// コピー先の変数をコピー元に置き換え、不要なコピー文を削除できるなら削除する
 fn replace_copy(
+    func_ty: &FuncType,
     code: &mut Code,
     _use_defs: &SecondaryMap<InstId, HashSet<Def>>,
     def_uses: &HashMap<Def, HashSet<InstId>>,
@@ -430,8 +432,14 @@ fn replace_copy(
             };
 
             // 2つの変数のdefaultを合わせる
-            if code.vars[src].default.is_none() && code.vars[dst].default.is_some() {
-                code.vars[src].default = code.vars[dst].default;
+            if code.vars[src].default.is_none() {
+                if code.vars[dst].default.is_some() {
+                    // コピー先にdefaultが存在する場合、コピー元にコピー先のdefaultを設定
+                    code.vars[src].default = code.vars[dst].default;
+                } else if dst.index() < func_ty.params().len() {
+                    // コピー先が引数の場合、コピー元のdefaultに変数の型のデフォルト値を設定
+                    code.vars[src].default = Some(code.vars[src].ty.default());
+                }
             }
         }
     }
@@ -442,6 +450,7 @@ mod tests {
     use std::collections::HashSet;
 
     use cranelift_entity::{EntityRef, SecondaryMap};
+    use wasmparser::{FuncType, ValType::I32};
 
     use crate::ir::{
         builder::Builder,
@@ -1126,6 +1135,7 @@ mod tests {
         // 1: v4 = v2;
         // 2: v5 = v3 + v4;
 
+        let func_ty = FuncType::new(vec![I32, I32], vec![]);
         let mut builder = Builder::new(&[]);
 
         let v1 = builder.new_var(Var {
@@ -1155,7 +1165,7 @@ mod tests {
         let mut reach_sets = SecondaryMap::new();
         let (use_defs, def_uses) = reaching_def(&code, Some(&mut reach_sets));
         let copy_sets = copy(&code);
-        replace_copy(&mut code, &use_defs, &def_uses, &copy_sets);
+        replace_copy(&func_ty, &mut code, &use_defs, &def_uses, &copy_sets);
 
         code_eq_nop(&code, &[/* 0 */ true, /* 1 */ true, /* 2 */ false]);
     }
@@ -1169,6 +1179,7 @@ mod tests {
         // 3: v2 = x + tmp
         // 4: return v2
 
+        let func_ty = FuncType::new(vec![I32], vec![]);
         let mut builder = Builder::new(&[]);
 
         let x = builder.new_var(Var {
@@ -1220,7 +1231,7 @@ mod tests {
             "copy",
         );
 
-        replace_copy(&mut code, &use_defs, &def_uses, &copy_sets);
+        replace_copy(&func_ty, &mut code, &use_defs, &def_uses, &copy_sets);
         code_eq_nop(
             &code,
             &[

--- a/src/pass/copy_propagation.rs
+++ b/src/pass/copy_propagation.rs
@@ -447,19 +447,11 @@ fn replace_copy(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use wasmparser::ValType::I32;
 
-    use cranelift_entity::{EntityRef, SecondaryMap};
-    use wasmparser::{FuncType, ValType::I32};
+    use crate::ir::{builder::Builder, ty::Const, var::Var};
 
-    use crate::ir::{
-        builder::Builder,
-        code::{Breakable, Code, InstId, InstKind},
-        ty::Const,
-        var::{Var, VarId},
-    };
-
-    use super::{copy, reaching_def, replace_copy, Def};
+    use super::*;
 
     #[test]
     fn copy_propagation_block() {

--- a/src/pass/var.rs
+++ b/src/pass/var.rs
@@ -66,7 +66,7 @@ mod tests {
         var::Var,
     };
 
-    use super::remove_unused_vars;
+    use super::*;
 
     #[test]
     fn test_remove_unused_vars() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -42,119 +42,130 @@ macro_rules! test_ignore {
     };
 }
 
-test!(test_address, "address");
-test!(test_align, "align");
-test!(test_binary_leb128, "binary-leb128");
-test!(test_binary, "binary");
-test!(test_block, "block");
-test!(test_br, "br");
-test!(test_br_if, "br_if");
-test_ignore!(test_br_table, "br_table");
-test!(test_break_drop, "break-drop");
-test!(test_call, "call");
-test!(test_call_indirect, "call_indirect");
-test!(test_comments, "comments");
-test!(test_const, "const");
-test!(test_conversions, "conversions");
-test!(test_custom, "custom");
-test!(test_data, "data");
-test!(test_elem, "elem");
-test!(test_endianness, "endianness");
-test!(test_exports, "exports");
-test!(test_f32, "f32");
+test!(test_address, "testsuite/address");
+test!(test_align, "testsuite/align");
+test!(test_binary_leb128, "testsuite/binary-leb128");
+test!(test_binary, "testsuite/binary");
+test!(test_block, "testsuite/block");
+test!(test_br, "testsuite/br");
+test!(test_br_if, "testsuite/br_if");
+test_ignore!(test_br_table, "testsuite/br_table");
+test!(test_break_drop, "testsuite/break-drop");
+test!(test_call, "testsuite/call");
+test!(test_call_indirect, "testsuite/call_indirect");
+test!(test_comments, "testsuite/comments");
+test!(test_const, "testsuite/const");
+test!(test_conversions, "testsuite/conversions");
+test!(test_custom, "testsuite/custom");
+test!(test_data, "testsuite/data");
+test!(test_elem, "testsuite/elem");
+test!(test_endianness, "testsuite/endianness");
+test!(test_exports, "testsuite/exports");
+test!(test_f32, "testsuite/f32");
 test!(
     test_f32_bitwise,
-    "f32_bitwise",
+    "testsuite/f32_bitwise",
     &deny_float_nan_case(&["copysign"])
 );
-test!(test_f32_cmp, "f32_cmp");
-test!(test_f64, "f64");
+test!(test_f32_cmp, "testsuite/f32_cmp");
+test!(test_f64, "testsuite/f64");
 test!(
     test_f64_bitwise,
-    "f64_bitwise",
+    "testsuite/f64_bitwise",
     &deny_float_nan_case(&["copysign"])
 );
-test!(test_f64_cmp, "f64_cmp");
-test!(test_fac, "fac");
-test!(test_float_exprs, "float_exprs");
-test!(test_float_literals, "float_literals");
-test!(test_float_memory, "float_memory");
+test!(test_f64_cmp, "testsuite/f64_cmp");
+test!(test_fac, "testsuite/fac");
+test!(test_float_exprs, "testsuite/float_exprs");
+test!(test_float_literals, "testsuite/float_literals");
+test!(test_float_memory, "testsuite/float_memory");
 test!(
     test_float_misc,
-    "float_misc",
+    "testsuite/float_misc",
     &deny_float_nan_case(&["f32.copysign", "f64.copysign"])
 );
-test!(test_forward, "forward");
-test!(test_func, "func");
-test!(test_func_ptrs, "func_ptrs");
-test!(test_globals, "globals");
-test!(test_if, "if");
-// test!(test_imports, "imports");
-// test!(test_inline_module, "inline-module");
-test!(test_int_exprs, "int_exprs");
-test!(test_int_literals, "int_literals");
-test!(test_labels, "labels");
-test!(test_left_to_right, "left-to-right");
-// test!(test_linking, "linking");
-test!(test_load, "load");
-test!(test_local_get, "local_get");
-test!(test_local_set, "local_set");
-test!(test_local_tee, "local_tee");
-test!(test_loop, "loop");
-test!(test_memory, "memory");
-test!(test_memory_grow, "memory_grow");
-test!(test_memory_redundancy, "memory_redundancy");
-test!(test_memory_size, "memory_size");
-test!(test_memory_trap, "memory_trap");
-// test!(test_names, "names");
-test!(test_nop, "nop");
-test!(test_return, "return");
-test!(test_select, "select");
-test!(test_skip_stack_guard_page, "skip-stack-guard-page");
-test!(test_stack, "stack");
-test!(test_start, "start");
-test!(test_store, "store");
-test!(test_switch, "switch");
-test!(test_table, "table");
-test!(test_token, "token");
-test!(test_traps, "traps");
-test!(test_type, "type");
-test!(test_typecheck, "typecheck");
-test!(test_unreachable, "unreachable");
-test!(test_unreached_invalid, "unreached-invalid");
-test!(test_unwind, "unwind");
-test!(test_utf8_custom_section_id, "utf8-custom-section-id");
-test!(test_utf8_import_field, "utf8-import-field");
-test!(test_utf8_import_module, "utf8-import-module");
-test!(test_utf8_invalid_encoding, "utf8-invalid-encoding");
+test!(test_forward, "testsuite/forward");
+test!(test_func, "testsuite/func");
+test!(test_func_ptrs, "testsuite/func_ptrs");
+test!(test_globals, "testsuite/globals");
+test!(test_if, "testsuite/if");
+// test!(test_imports, "testsuite/imports");
+// test!(test_inline_module, "testsuite/inline-module");
+test!(test_int_exprs, "testsuite/int_exprs");
+test!(test_int_literals, "testsuite/int_literals");
+test!(test_labels, "testsuite/labels");
+test!(test_left_to_right, "testsuite/left-to-right");
+// test!(test_linking, "testsuite/linking");
+test!(test_load, "testsuite/load");
+test!(test_local_get, "testsuite/local_get");
+test!(test_local_set, "testsuite/local_set");
+test!(test_local_tee, "testsuite/local_tee");
+test!(test_loop, "testsuite/loop");
+test!(test_memory, "testsuite/memory");
+test!(test_memory_grow, "testsuite/memory_grow");
+test!(test_memory_redundancy, "testsuite/memory_redundancy");
+test!(test_memory_size, "testsuite/memory_size");
+test!(test_memory_trap, "testsuite/memory_trap");
+// test!(test_names, "testsuite/names");
+test!(test_nop, "testsuite/nop");
+test!(test_return, "testsuite/return");
+test!(test_select, "testsuite/select");
+test!(
+    test_skip_stack_guard_page,
+    "testsuite/skip-stack-guard-page"
+);
+test!(test_stack, "testsuite/stack");
+test!(test_start, "testsuite/start");
+test!(test_store, "testsuite/store");
+test!(test_switch, "testsuite/switch");
+test!(test_table, "testsuite/table");
+test!(test_token, "testsuite/token");
+test!(test_traps, "testsuite/traps");
+test!(test_type, "testsuite/type");
+test!(test_typecheck, "testsuite/typecheck");
+test!(test_unreachable, "testsuite/unreachable");
+test!(test_unreached_invalid, "testsuite/unreached-invalid");
+test!(test_unwind, "testsuite/unwind");
+test!(
+    test_utf8_custom_section_id,
+    "testsuite/utf8-custom-section-id"
+);
+test!(test_utf8_import_field, "testsuite/utf8-import-field");
+test!(test_utf8_import_module, "testsuite/utf8-import-module");
+test!(
+    test_utf8_invalid_encoding,
+    "testsuite/utf8-invalid-encoding"
+);
 
 // Non-trapping float-to-int conversions
 test!(
     test_nontrapping_float_to_int_conversions,
-    "proposals/nontrapping-float-to-int-conversions/conversions"
+    "testsuite/proposals/nontrapping-float-to-int-conversions/conversions"
 );
 
 // Sign-extension operators
 test!(
     test_sign_extension_ops_i32,
-    "proposals/sign-extension-ops/i32",
+    "testsuite/proposals/sign-extension-ops/i32",
     &deny_int_neg_max_case(&["rem_s"])
 );
 test!(
     test_sign_extension_ops_i64,
-    "proposals/sign-extension-ops/i64",
+    "testsuite/proposals/sign-extension-ops/i64",
     &deny_int_neg_max_case(&["rem_s"])
 );
 
 // Bulk memory operations
 test!(
     test_memory_copy,
-    "proposals/bulk-memory-operations/memory_copy"
+    "testsuite/proposals/bulk-memory-operations/memory_copy"
 );
 test!(
     test_memory_fill,
-    "proposals/bulk-memory-operations/memory_fill"
+    "testsuite/proposals/bulk-memory-operations/memory_fill"
 );
+
+test!(test_uninit_variable, "uninit-variable");
 
 // traitのエイリアス
 trait Filter: Fn(&WastDirective<'_>) -> bool {}
@@ -206,7 +217,7 @@ fn deny_int_neg_max_case(names: &'static [&'static str]) -> impl Filter {
 fn test_wast(name: &str, filter: Option<&dyn Filter>) {
     let buf = read_to_string("tests/spectest.wast").unwrap();
 
-    let mut wast_path: PathBuf = PathBuf::from("tests/testsuite/");
+    let mut wast_path: PathBuf = PathBuf::from("tests/");
     wast_path.push(name);
     wast_path.set_extension("wast");
 

--- a/tests/uninit-variable.wast
+++ b/tests/uninit-variable.wast
@@ -1,0 +1,19 @@
+(module
+  (func (export "uninit-variable") (param i32) (result i32)
+    loop
+      i32.const 1
+      local.tee 0
+      i32.eqz
+      br_if 0
+      local.get 0
+      i32.const 0
+      i32.add
+      local.tee 0
+      i32.eqz
+      br_if 0
+    end
+    local.get 0
+  )
+)
+
+(assert_return (invoke "uninit-variable" (i32.const 0)) (i32.const 1))

--- a/tests/uninit-variable.wast
+++ b/tests/uninit-variable.wast
@@ -1,5 +1,5 @@
 (module
-  (func (export "uninit-variable") (param i32) (result i32)
+  (func (export "copy-propagation-param") (param i32) (result i32)
     loop
       i32.const 1
       local.tee 0
@@ -16,4 +16,4 @@
   )
 )
 
-(assert_return (invoke "uninit-variable" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "copy-propagation-param" (i32.const 0)) (i32.const 1))


### PR DESCRIPTION
Copy Propagationが行われる際、関数の引数である変数がデフォルト値のない変数に置き換えられる際、未割り当てのローカル変数が使用される場合があった。
この場合に、置き換え後の変数にデフォルト値を設定することでバグを修正した。