### PR TITLE
再帰呼び出しの変数保存処理で戻り値が上書きされていたのを修正

### DIFF
--- a/src/codegen/code.rs
+++ b/src/codegen/code.rs
@@ -154,7 +154,6 @@ fn filtered_save_vars(call: &Call, result: Option<VarId>) -> Vec<VarId> {
 fn push_save_vars(f: &mut dyn io::Write, call: &Call, result: Option<VarId>) -> io::Result<()> {
     let save_vars = filtered_save_vars(call, result);
     if !save_vars.is_empty() {
-
         // ローカル変数保存用のスタックにプッシュ
         for (i, &var) in save_vars.iter().enumerate() {
             write!(f, "{STACK}[{STACK_TOP}")?;
@@ -176,7 +175,6 @@ fn pop_save_vars(
 ) -> io::Result<()> {
     let save_vars = filtered_save_vars(call, result);
     if !save_vars.is_empty() {
-
         writeln!(f, "{STACK_TOP} -= {};", save_vars.len())?;
 
         // ローカル変数保存用のスタックからポップ
@@ -207,11 +205,7 @@ fn pop_save_vars(
 mod tests {
     use std::collections::HashSet;
 
-    use crate::ir::{
-        builder::Builder,
-        code::Call,
-        var::Var,
-    };
+    use crate::ir::{builder::Builder, code::Call, var::Var};
 
     use super::filtered_save_vars;
 

--- a/src/codegen/code.rs
+++ b/src/codegen/code.rs
@@ -3,6 +3,7 @@ use std::io;
 use crate::ir::{
     code::{BlockId, Breakable, Call, Code, InstId, InstKind},
     module::Module,
+    var::VarId,
     BREAK_DEPTH, LOOP, STACK, STACK_TOP,
 };
 
@@ -38,7 +39,7 @@ fn codegen_inst(
     let pattern = inst.expand_pattern(module);
 
     if let Some(call) = &inst.call {
-        push_save_vars(f, call)?;
+        push_save_vars(f, call, inst.result)?;
     }
 
     match &inst.kind {
@@ -130,15 +131,29 @@ fn codegen_inst(
     }
 
     if let Some(call) = &inst.call {
-        pop_save_vars(f, call, code)?;
+        pop_save_vars(f, call, code, inst.result)?;
     }
     Ok(())
 }
 
-fn push_save_vars(f: &mut dyn io::Write, call: &Call) -> io::Result<()> {
-    if call.recursive && !call.save_vars.is_empty() {
-        let mut save_vars = call.save_vars.iter().copied().collect::<Vec<_>>();
-        save_vars.sort();
+fn filtered_save_vars(call: &Call, result: Option<VarId>) -> Vec<VarId> {
+    if !call.recursive {
+        return Vec::new();
+    }
+
+    let mut save_vars = call
+        .save_vars
+        .iter()
+        .copied()
+        .filter(|&var_id| Some(var_id) != result)
+        .collect::<Vec<_>>();
+    save_vars.sort();
+    save_vars
+}
+
+fn push_save_vars(f: &mut dyn io::Write, call: &Call, result: Option<VarId>) -> io::Result<()> {
+    let save_vars = filtered_save_vars(call, result);
+    if !save_vars.is_empty() {
 
         // ローカル変数保存用のスタックにプッシュ
         for (i, &var) in save_vars.iter().enumerate() {
@@ -153,10 +168,14 @@ fn push_save_vars(f: &mut dyn io::Write, call: &Call) -> io::Result<()> {
     Ok(())
 }
 
-fn pop_save_vars(f: &mut dyn io::Write, call: &Call, code: &Code) -> io::Result<()> {
-    if call.recursive && !call.save_vars.is_empty() {
-        let mut save_vars = call.save_vars.iter().copied().collect::<Vec<_>>();
-        save_vars.sort();
+fn pop_save_vars(
+    f: &mut dyn io::Write,
+    call: &Call,
+    code: &Code,
+    result: Option<VarId>,
+) -> io::Result<()> {
+    let save_vars = filtered_save_vars(call, result);
+    if !save_vars.is_empty() {
 
         writeln!(f, "{STACK_TOP} -= {};", save_vars.len())?;
 
@@ -182,4 +201,35 @@ fn pop_save_vars(f: &mut dyn io::Write, call: &Call, code: &Code) -> io::Result<
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use crate::ir::{
+        builder::Builder,
+        code::Call,
+        var::Var,
+    };
+
+    use super::filtered_save_vars;
+
+    #[test]
+    fn excludes_recursive_call_result_from_saved_vars() {
+        let mut builder = Builder::new(&[]);
+        let var0 = builder.new_var(Var::default());
+        let var1 = builder.new_var(Var::default());
+
+        let call = Call {
+            func: 0,
+            recursive: true,
+            save_vars: HashSet::from([var0, var1]),
+            save_loop_vars: Default::default(),
+        };
+
+        assert_eq!(filtered_save_vars(&call, Some(var0)), vec![var1]);
+        assert_eq!(filtered_save_vars(&call, Some(var1)), vec![var0]);
+        assert_eq!(filtered_save_vars(&call, None), vec![var0, var1]);
+    }
 }

--- a/src/parse/code.rs
+++ b/src/parse/code.rs
@@ -27,7 +27,7 @@ macro_rules! define_single_visit_operator {
     ( @sign_extension $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident) => {};
     ( @bulk_memory $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident) => {};
     ( @$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident) => {
-        fn $visit(&mut self $($(,$arg: $argty)*)?) -> Self::Output {
+        fn $visit(&mut self $($(, _: $argty)*)?) -> Self::Output {
             panic!(stringify!($proposal))
         }
     };

--- a/src/parse/module.rs
+++ b/src/parse/module.rs
@@ -215,11 +215,10 @@ impl<'input, 'module> ModuleParser<'input, 'module> {
 
                 self.code_idx += 1;
             }
-            CustomSection(s) => {
-                if s.name() == "name" {
+            CustomSection(s)
+                if s.name() == "name" => {
                     self.apply_names(s)?;
                 }
-            }
             _other => {}
         }
         Ok(())

--- a/src/parse/module.rs
+++ b/src/parse/module.rs
@@ -215,10 +215,9 @@ impl<'input, 'module> ModuleParser<'input, 'module> {
 
                 self.code_idx += 1;
             }
-            CustomSection(s)
-                if s.name() == "name" => {
-                    self.apply_names(s)?;
-                }
+            CustomSection(s) if s.name() == "name" => {
+                self.apply_names(s)?;
+            }
             _other => {}
         }
         Ok(())


### PR DESCRIPTION
再帰呼び出しでは、対象関数の呼び出し前にローカル変数をスタック配列`w2us_stack`に保存し、呼び出し後に変数の内容を復元する。
この際、誤って呼び出し結果の戻り値が保存対象に含まれており、呼び出し後に戻り値が上書きされていた。
このPRではこれを修正する。

また、Rustのバージョンアップにより、マクロの未使用変数の警告が追加されたため、これを修正する。

このパッチはlox9973氏によって提供された。